### PR TITLE
Initial setup and PyPIReleaseSource

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.11, 3.12, 3.13]
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install package with dev extras
+        run: python -m pip install -e .[dev]
+
+      - name: Run tests
+        run: python -m pytest -v

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,9 +22,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Upgrade pip
-        run: python -m pip install --upgrade pip
-
       - name: Install package with dev extras
         run: python -m pip install -e .[dev]
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# pixi
+pixi.lock
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 OMSF Ecosystem Infrastructure Dev
+Copyright (c) 2025 OMSF Ecosystem Infrastructure Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # spec0
+
 Check what versions of a package should be supported according to SPEC0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,55 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "spec0"
+version = "0.0.1.dev0"
+description = "A tool to check which versions of a package should be supported according to SPEC0."
+authors = [
+  { name = "David W.H. Swenson", email = "dwhs@hyperblazer.net" }
+]
+readme = "README.md"
+license = { file = "LICENSE" }
+requires-python = ">=3.11,<4"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]
+keywords = ["spec0", "package support", "cli"]
+
+dependencies = [
+  "requests",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest",
+  "responses",
+  "black",
+  "pre-commit",
+]
+
+[tool.setuptools]
+packages = ["spec0"]
+package-dir = { "" = "src" }
+
+[tool.pixi.project]
+channels = ["conda-forge"]
+platforms = ["osx-64"]
+
+[tool.pixi.pypi-dependencies]
+spec0 = { path = ".", editable = true }
+
+[tool.pixi.environments]
+default = { solve-group = "default" }
+dev = { features = ["dev"], solve-group = "default" }
+
+[tool.pixi.tasks]

--- a/spec0/releasesource.py
+++ b/spec0/releasesource.py
@@ -1,7 +1,8 @@
 import dataclasses
 import datetime
 import requests
-from packaging.version import Version
+import warnings
+from packaging.version import Version, InvalidVersion
 
 
 @dataclasses.dataclass
@@ -33,7 +34,7 @@ class PyPIReleaseSource(ReleaseSource):
             try:
                 parsed_version = Version(version_str)
             except InvalidVersion:
-                warnings.warn(f"Skipping invalid version '{version_str}' for package '{package_name}'.")
+                warnings.warn(f"Skipping invalid version '{version_str}' for package '{package}'.")
                 continue
 
             # Determine earliest upload time among all distributions for that version

--- a/spec0/releasesource.py
+++ b/spec0/releasesource.py
@@ -1,0 +1,100 @@
+import dataclasses
+import datetime
+import requests
+from packaging.version import Version
+
+
+@dataclasses.dataclass
+class Release:
+    version: Version
+    release_date: datetime.datetime
+
+
+class ReleaseSource:
+    def _get_releases(self, package: str) -> list[Release]:
+        raise NotImplementedError
+
+    def get_releases(self, package: str) -> list[Release]:
+        yield from self._get_releases(package)
+
+
+class PyPIReleaseSource(ReleaseSource):
+    def _get_releases(self, package: str) -> list[Release]:
+        url = f"https://pypi.org/pypi/{package}/json"
+        response = requests.get(url)
+        response.raise_for_status()
+        data = response.json()
+
+        releases_data = data.get("releases", {})
+        release_list = []
+
+        for version_str, files in releases_data.items():
+            # Attempt to parse the version string
+            try:
+                parsed_version = Version(version_str)
+            except InvalidVersion:
+                warnings.warn(f"Skipping invalid version '{version_str}' for package '{package_name}'.")
+                continue
+
+            # Determine earliest upload time among all distributions for that version
+            earliest_date = None
+            for file_info in files:
+                upload_time_str = file_info.get("upload_time_iso_8601")
+                if upload_time_str:
+                    dt = datetime.datetime.fromisoformat(upload_time_str.replace("Z", "+00:00"))
+                    if earliest_date is None or dt < earliest_date:
+                        earliest_date = dt
+
+            # Only add to list if we successfully found an upload date
+            if earliest_date is not None:
+                release_list.append(Release(version=parsed_version,
+                                            release_date=earliest_date))
+
+        # Sort releases by date descending (newest first)
+        release_list.sort(key=lambda r: r.release_date, reverse=True)
+
+        # Yield them in sorted order
+        for release in release_list:
+            yield release
+
+
+
+class GitHubReleaseSource(ReleaseSource):
+    def _get_releases(self, package: str) -> list[Release]:
+        ...
+
+
+class GitHubTagReleaseSource(ReleaseSource):
+    def _get_releases(self, package: str) -> list[Release]:
+        ...
+
+
+class CondaReleaseSource(ReleaseSource):
+    def __init__(self, channel_platforms: list[str] = None):
+        self.platforms = platforms or ["conda-forge/linux-64",
+                                       "conda-forge/noarch"]
+
+    def get_releases(self, package: str) -> list[Release]:
+        ...
+
+
+class DefaultReleaseSource(ReleaseSource):
+    def _try_release_source(self, source: ReleaseSource, package: str):
+        try:
+            return source.get_releases(package)
+        except:
+            return None
+
+    def get_releases(self, package: str) -> list[Release]:
+        sources = [
+            PyPIReleaseSource(),
+            GitHubReleaseSource(),
+            GitHubTagReleaseSource(),
+            CondaForgeReleaseSource()
+        ]
+        for source in sources:
+            releases = self._try_release_source(source, package)
+            if releases:
+                return releases
+
+        raise ValueError(f"Failed to get releases for {package}")

--- a/spec0/releasesource.py
+++ b/spec0/releasesource.py
@@ -34,7 +34,9 @@ class PyPIReleaseSource(ReleaseSource):
             try:
                 parsed_version = Version(version_str)
             except InvalidVersion:
-                warnings.warn(f"Skipping invalid version '{version_str}' for package '{package}'.")
+                warnings.warn(
+                    f"Skipping invalid version '{version_str}' for package '{package}'."
+                )
                 continue
 
             # Determine earliest upload time among all distributions for that version
@@ -42,14 +44,17 @@ class PyPIReleaseSource(ReleaseSource):
             for file_info in files:
                 upload_time_str = file_info.get("upload_time_iso_8601")
                 if upload_time_str:
-                    dt = datetime.datetime.fromisoformat(upload_time_str.replace("Z", "+00:00"))
+                    dt = datetime.datetime.fromisoformat(
+                        upload_time_str.replace("Z", "+00:00")
+                    )
                     if earliest_date is None or dt < earliest_date:
                         earliest_date = dt
 
             # Only add to list if we successfully found an upload date
             if earliest_date is not None:
-                release_list.append(Release(version=parsed_version,
-                                            release_date=earliest_date))
+                release_list.append(
+                    Release(version=parsed_version, release_date=earliest_date)
+                )
 
         # Sort releases by date descending (newest first)
         release_list.sort(key=lambda r: r.release_date, reverse=True)
@@ -57,7 +62,6 @@ class PyPIReleaseSource(ReleaseSource):
         # Yield them in sorted order
         for release in release_list:
             yield release
-
 
 
 class GitHubReleaseSource(ReleaseSource):
@@ -72,8 +76,7 @@ class GitHubTagReleaseSource(ReleaseSource):
 
 class CondaReleaseSource(ReleaseSource):
     def __init__(self, channel_platforms: list[str] = None):
-        self.platforms = platforms or ["conda-forge/linux-64",
-                                       "conda-forge/noarch"]
+        self.platforms = platforms or ["conda-forge/linux-64", "conda-forge/noarch"]
 
     def get_releases(self, package: str) -> list[Release]:
         ...
@@ -91,7 +94,7 @@ class DefaultReleaseSource(ReleaseSource):
             PyPIReleaseSource(),
             GitHubReleaseSource(),
             GitHubTagReleaseSource(),
-            CondaForgeReleaseSource()
+            CondaForgeReleaseSource(),
         ]
         for source in sources:
             releases = self._try_release_source(source, package)

--- a/tests/requires_internet.py
+++ b/tests/requires_internet.py
@@ -1,0 +1,31 @@
+import socket
+import functools
+import pytest
+
+_HAS_INTERNET = None
+
+
+def _check_internet():
+    """Checks internet connectivity exactly once per session run."""
+    global _HAS_INTERNET
+    if _HAS_INTERNET is None:
+        try:
+            socket.create_connection(("www.google.com", 80), timeout=2)
+            _HAS_INTERNET = True
+        except OSError:
+            _HAS_INTERNET = False
+    return _HAS_INTERNET
+
+
+def requires_internet(test_func):
+    """
+    Decorator: Skip test if there is no internet connection.
+    """
+
+    @functools.wraps(test_func)
+    def wrapper(*args, **kwargs):
+        if not _check_internet():
+            pytest.skip("Skipping test because there is no internet connection.")
+        return test_func(*args, **kwargs)
+
+    return wrapper

--- a/tests/test_releasesource.py
+++ b/tests/test_releasesource.py
@@ -1,0 +1,103 @@
+import pytest
+import responses
+import warnings
+import datetime
+from packaging.version import Version
+
+from requires_internet import requires_internet
+
+from spec0.releasesource import *
+
+MOCK_RESPONSE_VALID_ONLY = {
+    "releases": {
+        "2.2.0": [{"upload_time_iso_8601": "2023-03-03T12:00:00Z"}],
+        "2.1.0": [{"upload_time_iso_8601": "2023-02-10T09:00:00Z"}],
+        "1.9.0": [{"upload_time_iso_8601": "2023-01-15T20:00:00Z"}],
+    }
+}
+
+MOCK_RESPONSE_MIXED = {
+    "releases": {
+        "10.0.0": [{"upload_time_iso_8601": "2024-01-01T12:00:00Z"}],
+        "not-a-valid-version": [{"upload_time_iso_8601": "2024-01-02T12:00:00Z"}],
+        "9.9.9": [{"upload_time_iso_8601": "2023-12-15T12:00:00Z"}],
+    }
+}
+
+
+def assert_is_descending(dates):
+    """
+    Assert that a list of datetimes is sorted in descending order.
+    (i.e., each date is newer or the same as the next)
+    """
+    assert all(dates[i] >= dates[i + 1] for i in range(len(dates) - 1))
+
+
+class TestPyPIReleaseSource:
+    @responses.activate
+    def test_valid_only_versions(self):
+        url = "https://pypi.org/pypi/example-lib-valid/json"
+        responses.add(
+            method=responses.GET,
+            url=url,
+            json=MOCK_RESPONSE_VALID_ONLY,
+            status=200,
+        )
+
+        source = PyPIReleaseSource()
+        releases = list(source.get_releases("example-lib-valid"))
+
+        assert len(releases) == 3
+        versions = [r.version for r in releases]
+        assert versions == [Version("2.2.0"), Version("2.1.0"), Version("1.9.0")]
+
+        release_dates = [r.release_date for r in releases]
+        assert_is_descending(release_dates)
+        assert release_dates == [
+            datetime.datetime(2023, 3, 3, 12, 0, tzinfo=datetime.timezone.utc),
+            datetime.datetime(2023, 2, 10, 9, 0, tzinfo=datetime.timezone.utc),
+            datetime.datetime(2023, 1, 15, 20, 0, tzinfo=datetime.timezone.utc),
+        ]
+
+    @responses.activate
+    def test_mixed_versions_warning(self):
+        url = "https://pypi.org/pypi/example-lib-mixed/json"
+        responses.add(
+            method=responses.GET,
+            url=url,
+            json=MOCK_RESPONSE_MIXED,
+            status=200,
+        )
+
+        with pytest.warns(UserWarning, match="Skipping invalid version"):
+            warnings.simplefilter("always")
+            source = PyPIReleaseSource()
+            releases = list(source.get_releases("example-lib-mixed"))
+
+        assert len(releases) == 2
+        versions = [r.version for r in releases]
+        assert versions == [Version("10.0.0"), Version("9.9.9")]
+
+        release_dates = [r.release_date for r in releases]
+        assert_is_descending(release_dates)
+        assert release_dates == [
+            datetime.datetime(2024, 1, 1, 12, 0, tzinfo=datetime.timezone.utc),
+            datetime.datetime(2023, 12, 15, 12, 0, tzinfo=datetime.timezone.utc),
+        ]
+
+    @pytest.mark.parametrize("package_name", ["pandas", "numpy", "scipy"])
+    @requires_internet
+    def test_integration_packages(self, package_name):
+        """
+        Integration test that calls the real PyPI API for the given package.
+        Checks:
+          1) We get at least one release.
+          2) The release dates are in descending order.
+        """
+        source = PyPIReleaseSource()
+        releases = list(source.get_releases(package_name))
+
+        assert len(releases) > 0
+
+        dates = [r.release_date for r in releases]
+        assert_is_descending(dates)


### PR DESCRIPTION
The overall model here is that we'll may have multiple sources of release information (PyPI, conda, GitHub). We can then filter by version number and release date to determine what versions need to be supported according to some SPEC0/NEP29-like policy.

This PR is limited in scope to getting release versions from PyPI. Future PRs will add other sources.