### PR TITLE
Fix typing.Generator

### DIFF
--- a/src/spec0/releasesource.py
+++ b/src/spec0/releasesource.py
@@ -71,18 +71,18 @@ class PyPIReleaseSource(ReleaseSource):
 
 
 class GitHubReleaseSource(ReleaseSource):
-    def _get_releases(self, package: str) -> Generator[Release]: ...
+    def _get_releases(self, package: str) -> Generator[Release, None, None]: ...
 
 
 class GitHubTagReleaseSource(ReleaseSource):
-    def _get_releases(self, package: str) -> Generator[Release]: ...
+    def _get_releases(self, package: str) -> Generator[Release, None, None]: ...
 
 
 class CondaReleaseSource(ReleaseSource):
     def __init__(self, channel_platforms: list[str] = None):
         self.platforms = platforms or ["conda-forge/linux-64", "conda-forge/noarch"]
 
-    def get_releases(self, package: str) -> Generator[Release]: ...
+    def get_releases(self, package: str) -> Generator[Release, None, None]: ...
 
 
 class DefaultReleaseSource(ReleaseSource):
@@ -92,7 +92,7 @@ class DefaultReleaseSource(ReleaseSource):
         except:
             return None
 
-    def get_releases(self, package: str) -> Generator[Release]:
+    def get_releases(self, package: str) -> Generator[Release, None, None]:
         sources = [
             PyPIReleaseSource(),
             GitHubReleaseSource(),

--- a/src/spec0/releasesource.py
+++ b/src/spec0/releasesource.py
@@ -18,10 +18,10 @@ class Release:
 class ReleaseSource:
     """ABC for a source of package releases."""
 
-    def _get_releases(self, package: str) -> Generator[Release]:
+    def _get_releases(self, package: str) -> Generator[Release, None, None]:
         raise NotImplementedError()
 
-    def get_releases(self, package: str) -> Generator[Release]:
+    def get_releases(self, package: str) -> Generator[Release, None, None]:
         yield from self._get_releases(package)
 
 
@@ -31,7 +31,7 @@ class PyPIReleaseSource(ReleaseSource):
     Typically, you only need one instance of this class.
     """
 
-    def _get_releases(self, package: str) -> Generator[Release]:
+    def _get_releases(self, package: str) -> Generator[Release, None, None]:
         url = f"https://pypi.org/pypi/{package}/json"
         response = requests.get(url)
         response.raise_for_status()
@@ -71,21 +71,18 @@ class PyPIReleaseSource(ReleaseSource):
 
 
 class GitHubReleaseSource(ReleaseSource):
-    def _get_releases(self, package: str) -> Generator[Release]:
-        ...
+    def _get_releases(self, package: str) -> Generator[Release]: ...
 
 
 class GitHubTagReleaseSource(ReleaseSource):
-    def _get_releases(self, package: str) -> Generator[Release]:
-        ...
+    def _get_releases(self, package: str) -> Generator[Release]: ...
 
 
 class CondaReleaseSource(ReleaseSource):
     def __init__(self, channel_platforms: list[str] = None):
         self.platforms = platforms or ["conda-forge/linux-64", "conda-forge/noarch"]
 
-    def get_releases(self, package: str) -> Generator[Release]:
-        ...
+    def get_releases(self, package: str) -> Generator[Release]: ...
 
 
 class DefaultReleaseSource(ReleaseSource):


### PR DESCRIPTION
Prior to Python 3.13, needed to provide send and return types, as well as yield type.

https://stackoverflow.com/a/57363282