### PR TITLE
SPEC0 release filters

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
         run: python -m pytest --cov -v
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml

--- a/src/spec0/releasefilter.py
+++ b/src/spec0/releasefilter.py
@@ -1,0 +1,136 @@
+import datetime
+from collections import defaultdict
+from typing import Iterable
+
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+from .releasesource import Release
+
+
+class ReleaseFilter:
+    def filter(self, package, releases): ...
+
+
+# class NEP29(ReleaseFilter):
+#     def __init__(self, n_versions=3, n_months=24, python_override=True):
+#         self.n_versions = n_versions
+#         self.n_months = n_months
+
+#     def filter(self, package, releases): ...
+
+
+# utils/dates
+def get_quarter(date):
+    """Convert a date to a quarter as tuple (year, quarter).
+
+    Quarters are 1-indexed.
+    """
+    return (date.year, ((date.month - 1) // 3) + 1)
+
+
+def next_quarter(date):
+    """Get the next quarter after the given date."""
+    year, quarter = get_quarter(date)
+    quarter += 1
+    if quarter > 4:
+        quarter = 1
+        year += 1
+    return (year, quarter)
+
+
+def quarter_to_date(quarter):
+    """
+    Convert a quarter to the date associated with the start of that quarter.
+    """
+    year, quarter = quarter
+    return datetime.datetime(
+        year, (quarter - 1) * 3 + 1, 1, tzinfo=datetime.timezone.utc
+    )
+
+
+def shift_date_by_months(date, n_months):
+    # used to set the cutoff; if there's a better way to do this, go for it.
+    # Months are weird because they aren't all the same length.
+    dyears = n_months // 12
+    dmonths = n_months % 12
+    return date.replace(year=date.year + dyears, month=date.month + dmonths)
+
+
+def get_oldest_minor_release(releases: Iterable[Release]):
+    oldest_minor_release = defaultdict(
+        lambda: Release(
+            version=None,
+            release_date=datetime.datetime.max.replace(tzinfo=datetime.timezone.utc),
+        )
+    )
+
+    for release in releases:
+        if not release.version.is_prerelease:
+            key = (release.version.epoch, release.version.major, release.version.minor)
+            if release.release_date < oldest_minor_release[key].release_date:
+                oldest_minor_release[key] = release
+
+    return oldest_minor_release
+
+
+def make_specifier(supported_minor_releases, include_upper_bound=True):
+    """Create a specifier that includes all supported minor releases."""
+    min_version = min(
+        Version(f"{epoch}!{major}.{minor}")
+        for epoch, major, minor in supported_minor_releases.keys()
+    )
+    spec = SpecifierSet(f">={min_version}")
+    if include_upper_bound:
+        upper_bound = max(
+            Version(f"{epoch}!{major + 1}")
+            for epoch, major, minor in supported_minor_releases.keys()
+        )
+        spec &= SpecifierSet(f"<{upper_bound}")
+    return spec
+
+
+class SPEC0(ReleaseFilter):
+    """Filter using SPEC0 rules (time-only)"""
+
+    def __init__(self, n_months=24, python_override=True):
+        self.n_months = n_months
+        self.python_override = python_override
+
+    def _get_n_months(self, package: str):
+        if package == "python" and self.python_override:
+            return 36
+        return self.n_months
+
+    def _get_minimum_supported(self, package: str, releases: Iterable[Release]):
+        oldest_minor_release = get_oldest_minor_release(releases)
+
+        max_minor_release = max(oldest_minor_release)
+        # always support at least the most recent minor release
+        supported = {max_minor_release: oldest_minor_release[max_minor_release]}
+
+        now = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
+
+        for key, release in oldest_minor_release.items():
+            drop_date = self.drop_date(package, release)
+            if now < drop_date:
+                supported[key] = release
+
+        return supported
+
+    def drop_date(self, package, release):
+        raise NotImplementedError()
+
+
+class SPEC0StrictDate(SPEC0):
+    def drop_date(self, package, release):
+        n_months = self._get_n_months(package)
+        return shift_date_by_months(release.release_date, n_months)
+
+
+class SPEC0Quarter(SPEC0):
+    def drop_date(self, package, release):
+        n_months = self._get_n_months(package)
+        naive_drop = shift_date_by_months(release.release_date, n_months)
+        drop = quarter_to_date(next_quarter(naive_drop))
+        return drop

--- a/src/spec0/releasefilters.py
+++ b/src/spec0/releasefilters.py
@@ -12,14 +12,6 @@ class ReleaseFilter:
     def filter(self, package, releases): ...
 
 
-# class NEP29(ReleaseFilter):
-#     def __init__(self, n_versions=3, n_months=24, python_override=True):
-#         self.n_versions = n_versions
-#         self.n_months = n_months
-
-#     def filter(self, package, releases): ...
-
-
 # utils/dates
 def get_quarter(date):
     """Convert a date to a quarter as tuple (year, quarter).
@@ -122,6 +114,9 @@ class SPEC0(ReleaseFilter):
 
     def drop_date(self, package, release):
         raise NotImplementedError()
+
+    def filter(self, package, releases):
+        return self._get_minimum_supported(package, releases)
 
 
 class SPEC0StrictDate(SPEC0):

--- a/src/spec0/releasefilters.py
+++ b/src/spec0/releasefilters.py
@@ -50,6 +50,7 @@ def quarter_to_date(quarter):
 
 
 def shift_date_by_months(date, n_months):
+    """Shift a date by a number of months."""
     # used to set the cutoff; if there's a better way to do this, go for it.
     # Months are weird because they aren't all the same length.
     dyears = n_months // 12
@@ -58,6 +59,7 @@ def shift_date_by_months(date, n_months):
 
 
 def get_oldest_minor_release(releases: Iterable[Release]):
+    """Get the oldest release for each minor release version."""
     oldest_minor_release = defaultdict(
         lambda: Release(
             version=None,

--- a/tests/test_releasefilters.py
+++ b/tests/test_releasefilters.py
@@ -1,0 +1,196 @@
+import datetime
+import pytest
+from packaging.version import Version
+from unittest.mock import patch
+
+from spec0.releasefilters import *
+
+read_datetime = datetime.datetime
+
+
+@pytest.fixture
+def releases():
+    # a set of releases where, by strict date, 0 and 3 should be dropped,
+    # and by quarter, 0 should be dropped.
+    rA = Release(
+        version=Version("1.0.0"),
+        release_date=datetime.datetime(2021, 12, 15, tzinfo=datetime.timezone.utc),
+    )
+    rB = Release(
+        version=Version("1.1.0"),
+        release_date=datetime.datetime(2022, 6, 1, tzinfo=datetime.timezone.utc),
+    )
+    rC = Release(
+        version=Version("0.9.0"),
+        release_date=datetime.datetime(2022, 3, 1, tzinfo=datetime.timezone.utc),
+    )
+    rD = Release(
+        version=Version("1.2.0"),
+        release_date=datetime.datetime(2022, 1, 1, tzinfo=datetime.timezone.utc),
+    )
+    releases = [rA, rB, rC, rD]
+    return releases
+
+
+@pytest.mark.parametrize(
+    "datetime, expected",
+    [
+        (datetime.datetime(2023, 5, 15), (2023, 2)),
+        (datetime.datetime(2023, 1, 1), (2023, 1)),
+        (datetime.datetime(2023, 12, 31), (2023, 4)),
+    ],
+)
+def test_get_quarter(datetime, expected):
+    assert get_quarter(datetime) == expected
+
+
+@pytest.mark.parametrize(
+    "datetime, expected",
+    [
+        (datetime.datetime(2023, 5, 15), (2023, 3)),
+        (datetime.datetime(2023, 11, 1), (2024, 1)),  # bump the year
+    ],
+)
+def test_next_quarter(datetime, expected):
+    assert next_quarter(datetime) == expected
+
+
+def test_quarter_to_date():
+    expected = datetime.datetime(2023, 4, 1, tzinfo=datetime.timezone.utc)
+    assert quarter_to_date((2023, 2)) == expected
+
+
+@pytest.mark.parametrize(
+    "datetime, n_months, expected",
+    [
+        (datetime.datetime(2023, 1, 15), 3, datetime.datetime(2023, 4, 15)),
+        (datetime.datetime(2023, 7, 15), 4, datetime.datetime(2023, 11, 15)),
+    ],
+)
+def test_shift_date_by_months(datetime, n_months, expected):
+    assert shift_date_by_months(datetime, n_months) == expected
+
+
+def test_get_oldest_minor_release():
+    r1 = Release(
+        version=Version("1.0.0"),
+        release_date=datetime.datetime(2023, 1, 15, tzinfo=datetime.timezone.utc),
+    )
+    r2 = Release(
+        version=Version("1.0.0"),
+        release_date=datetime.datetime(2023, 1, 10, tzinfo=datetime.timezone.utc),
+    )
+    r3 = Release(
+        version=Version("1.1.0"),
+        release_date=datetime.datetime(2023, 2, 1, tzinfo=datetime.timezone.utc),
+    )
+    # pre-release: not included
+    r4 = Release(
+        version=Version("1.1.0a1"),
+        release_date=datetime.datetime(2023, 1, 5, tzinfo=datetime.timezone.utc),
+    )
+    releases = [r1, r2, r3, r4]
+    oldest = get_oldest_minor_release(releases)
+    # For (0,1,0), the oldest is r2; for (0,1,1), it is r3.
+    assert oldest[(0, 1, 0)] == r2
+    assert oldest[(0, 1, 1)] == r3
+
+
+@pytest.mark.parametrize("include_upper_bound", [True, False])
+def test_make_specifier(include_upper_bound):
+    r1 = Release(
+        version=Version("1.0.0"),
+        release_date=datetime.datetime(2023, 1, 15, tzinfo=datetime.timezone.utc),
+    )
+    r2 = Release(
+        version=Version("1.1.0"),
+        release_date=datetime.datetime(2023, 2, 15, tzinfo=datetime.timezone.utc),
+    )
+    supported = {(0, 1, 0): r1, (0, 1, 1): r2}
+    spec = make_specifier(supported, include_upper_bound=include_upper_bound)
+    assert Version("1.0.0") in spec
+    assert Version("1.5.0") in spec
+    assert (Version("2.0.0") in spec) is not include_upper_bound
+
+
+@pytest.mark.parametrize("package", ["python", "other"])
+@pytest.mark.parametrize("python_override", [True, False])
+def test_get_n_months(package, python_override):
+    if package == "python" and python_override:
+        expected = 36
+    else:
+        expected = 24
+    spec = SPEC0StrictDate(n_months=24, python_override=python_override)
+    assert spec._get_n_months(package) == expected
+
+
+class TestSPEC0StrictDate:
+    def test_get_minimum_supported(self, releases):
+        fixed_now = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
+        with patch(
+            "spec0.releasefilters.datetime.datetime", wraps=datetime.datetime
+        ) as mock_datetime:
+            mock_datetime.utcnow.return_value = fixed_now
+
+            spec_strict = SPEC0StrictDate(n_months=24, python_override=False)
+            supported = spec_strict._get_minimum_supported("foo", releases)
+            expected = releases[1:-1]
+            for release in expected:
+                key = (
+                    release.version.epoch,
+                    release.version.major,
+                    release.version.minor,
+                )
+                assert key in supported
+
+    @pytest.mark.parametrize("python_override", [True, False])
+    @pytest.mark.parametrize("package", ["foo", "python"])
+    def test_drop_date(self, python_override, package):
+        r = Release(
+            version=Version("1.0.0"),
+            release_date=datetime.datetime(2023, 1, 15, tzinfo=datetime.timezone.utc),
+        )
+        if python_override and package == "python":
+            expected = datetime.datetime(2026, 1, 15, tzinfo=datetime.timezone.utc)
+        else:
+            expected = datetime.datetime(2025, 1, 15, tzinfo=datetime.timezone.utc)
+        spec_strict = SPEC0StrictDate(n_months=24, python_override=python_override)
+        drop = spec_strict.drop_date(package, r)
+        assert drop == expected
+
+
+class TestSPEC0Quarter:
+    def test_get_minimum_supported(self, releases):
+        fixed_now = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
+        with patch(
+            "spec0.releasefilters.datetime.datetime", wraps=datetime.datetime
+        ) as mock_datetime:
+            mock_datetime.utcnow.return_value = fixed_now
+
+            spec_quarter = SPEC0Quarter(n_months=24, python_override=False)
+            supported = spec_quarter._get_minimum_supported("foo", releases)
+
+            expected = releases[1:]
+
+            for release in expected:
+                key = (
+                    release.version.epoch,
+                    release.version.major,
+                    release.version.minor,
+                )
+                assert key in supported
+
+    @pytest.mark.parametrize("python_override", [True, False])
+    @pytest.mark.parametrize("package", ["foo", "python"])
+    def test_drop_date(self, python_override, package):
+        r = Release(
+            version=Version("1.0.0"),
+            release_date=datetime.datetime(2023, 1, 15, tzinfo=datetime.timezone.utc),
+        )
+        if python_override and package == "python":
+            expected = datetime.datetime(2026, 4, 1, tzinfo=datetime.timezone.utc)
+        else:
+            expected = datetime.datetime(2025, 4, 1, tzinfo=datetime.timezone.utc)
+        spec0 = SPEC0Quarter(n_months=24, python_override=python_override)
+        drop = spec0.drop_date(package, r)
+        assert drop == expected

--- a/tests/test_releasefilters.py
+++ b/tests/test_releasefilters.py
@@ -125,7 +125,7 @@ def test_get_n_months(package, python_override):
 
 
 class TestSPEC0StrictDate:
-    def test_get_minimum_supported(self, releases):
+    def test_filter(self, releases):
         fixed_now = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
         with patch(
             "spec0.releasefilters.datetime.datetime", wraps=datetime.datetime
@@ -133,7 +133,7 @@ class TestSPEC0StrictDate:
             mock_datetime.utcnow.return_value = fixed_now
 
             spec_strict = SPEC0StrictDate(n_months=24, python_override=False)
-            supported = spec_strict._get_minimum_supported("foo", releases)
+            supported = spec_strict.filter("foo", releases)
             expected = releases[1:-1]
             for release in expected:
                 key = (
@@ -160,7 +160,7 @@ class TestSPEC0StrictDate:
 
 
 class TestSPEC0Quarter:
-    def test_get_minimum_supported(self, releases):
+    def test_filter(self, releases):
         fixed_now = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
         with patch(
             "spec0.releasefilters.datetime.datetime", wraps=datetime.datetime
@@ -168,7 +168,7 @@ class TestSPEC0Quarter:
             mock_datetime.utcnow.return_value = fixed_now
 
             spec_quarter = SPEC0Quarter(n_months=24, python_override=False)
-            supported = spec_quarter._get_minimum_supported("foo", releases)
+            supported = spec_quarter.filter("foo", releases)
 
             expected = releases[1:]
 


### PR DESCRIPTION
This includes two variants of SPEC0 filtering, because there are (at least?) two interpretations of the text in SPEC0.

One is the literal date of n_months (i.e., 2 years) after release. At that point, it is no longer supported.
The other is the suggestion in the SPEC of "the next release in a given quarter is considered as the one removing support for a given item." This is a little confusing (https://github.com/scientific-python/specs/issues/379), so my interpretation is the quarter after the n_months (so you always get at least 2 years).