### PR TITLE
CLI and refactoring utils

### DIFF
--- a/src/spec0/cli.py
+++ b/src/spec0/cli.py
@@ -1,0 +1,99 @@
+import argparse
+import logging
+
+from functools import partial
+
+from spec0.releasesource import PyPIReleaseSource, CondaReleaseSource
+from spec0.releasefilters import SPEC0StrictDate, SPEC0Quarter
+from spec0.output import terminal_output, json_output, specifier_output
+from spec0.main import main
+
+
+def make_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("package")
+    parser.add_argument("--log-level", default="WARNING")
+
+    source = parser.add_argument_group("Source")
+    source.add_argument("--pypi", action="store_true")
+    source.add_argument("--conda-channel")
+    source.add_argument("--conda-arch", nargs="+", default=["noarch", "linux-64"])
+    # source.add_argument('--github', action='store_true')
+
+    # filter options
+    filterg = parser.add_argument_group("Filter")
+    filterg.add_argument(
+        "--filter", choices=["spec0", "spec0quarterly"], default="spec0"
+    )
+    filterg.add_argument("--n-months", type=int, default=24)
+
+    # output options
+    output = parser.add_argument_group("Output")
+    output.add_argument(
+        "--output-columns", nargs="+", default=["package", "release-date", "drop-date"]
+    )
+    output.add_argument("--output-json", action="store_true")
+    output.add_argument("--output-specifier", action="store_true")
+
+    return parser
+
+
+def select_source(opts):
+    selected_pypi = opts.pypi
+    selected_conda = opts.conda_channel is not None
+    # selected_github = opts.github
+    n_selected = sum([selected_pypi, selected_conda])
+    if n_selected == 0:
+        source = None
+    elif n_selected > 1:
+        raise ValueError("Only one source can be selected")
+    else:
+        if selected_pypi:
+            source = [PyPIReleaseSource()]
+        elif selected_conda:
+            platforms = [f"{opts.conda_channel}/{arch}" for arch in opts.conda_arch]
+            source = [CondaReleaseSource(platforms)]
+        # elif selected_github:
+        #    source = GitHubReleaseSource()
+    return source
+
+
+def select_filter(opts):
+    if opts.filter == "spec0":
+        filter_ = SPEC0StrictDate(opts.n_months)
+    elif opts.filter == "spec0quarterly":
+        filter_ = SPEC0Quarter(opts.n_months)
+    return filter_
+
+
+def select_output(opts):
+    n_selected = sum([opts.output_json, opts.output_specifier])
+    if n_selected == 0:
+        release_date = "Release Date" in opts.output_columns
+        drop_date = "Drop Date" in opts.output_columns
+        output = partial(
+            terminal_output, release_date=release_date, drop_date=drop_date
+        )
+    elif n_selected > 1:
+        raise ValueError("Only one output can be selected")
+    else:
+        if opts.output_json:
+            output = json_output
+        elif opts.output_specifier:
+            output = specifier_output
+        else:
+            raise RuntimeError("This should never happen")
+    return output
+
+
+if __name__ == "__main__":
+    parser = make_parser()
+    opts = parser.parse_args()
+    logging.basicConfig(level=opts.log_level)  # eww
+
+    sources = select_source(opts)
+    filter_ = select_filter(opts)
+    output = select_output(opts)
+
+    results = main(opts.package, sources, filter_)
+    output(results)

--- a/src/spec0/main.py
+++ b/src/spec0/main.py
@@ -30,7 +30,8 @@ def main(package, sources=None, filter_=None):
         "package": package,
         "releases": [
             {
-                "release": release,
+                "version": release.version,
+                "release-date": release.release_date,
                 "drop-date": filter_.drop_date(package, release),
             }
             for release in filtered.values()
@@ -46,16 +47,14 @@ def _major_minor_str(version):
     return major_minor_str
 
 
-def terminal_output(releases, release_date=True, drop_date=True):
-    package = releases["package"]
+def terminal_output(pkg_info, release_date=True, drop_date=True):
+    package = pkg_info["package"]
     release_names = [
-        f"{package} {_major_minor_str(release['release'].version)}"
-        for release in releases["releases"]
+        f"{package} {_major_minor_str(release['version'])}"
+        for release in pkg_info["releases"]
     ]
-    release_dates = [
-        release["release"].release_date for release in releases["releases"]
-    ]
-    drop_dates = [release["drop-date"] for release in releases["releases"]]
+    release_dates = [release["release-date"] for release in pkg_info["releases"]]
+    drop_dates = [release["drop-date"] for release in pkg_info["releases"]]
     name_width = max(len("Package"), max(len(name) for name in release_names))
     date_format = "%Y-%m-%d"
     if release_date:

--- a/src/spec0/main.py
+++ b/src/spec0/main.py
@@ -1,0 +1,87 @@
+from spec0.releasesource import PyPIReleaseSource, CondaReleaseSource
+from spec0.releasefilters import SPEC0StrictDate
+
+
+def default_sources():
+    return [
+        PyPIReleaseSource(),
+        CondaReleaseSource(["conda-forge/noarch", "conda-forge/linux-64"]),
+    ]
+
+
+def default_filter():
+    return SPEC0StrictDate()
+
+
+def main(package, sources=None, filter_=None):
+    if sources is None:
+        sources = default_sources()
+
+    if filter_ is None:
+        filter_ = default_filter()
+
+    # we take the releases from the first source that has them
+    for source in sources:
+        if releases := source.get_releases(package):
+            break
+
+    filtered = filter_.filter(package, releases)
+    return {
+        "package": package,
+        "releases": [
+            {
+                "release": release,
+                "drop-date": filter_.drop_date(package, release),
+            }
+            for release in filtered.values()
+        ],
+    }
+
+
+def _major_minor_str(version):
+    major_minor_str = f"{version.major}.{version.minor}"
+    if version.epoch != 0:
+        major_minor_str = f"{version.epoch}!{major_minor_str}"
+
+    return major_minor_str
+
+
+def terminal_output(releases, release_date=True, drop_date=True):
+    package = releases["package"]
+    release_names = [
+        f"{package} {_major_minor_str(release['release'].version)}"
+        for release in releases["releases"]
+    ]
+    release_dates = [
+        release["release"].release_date for release in releases["releases"]
+    ]
+    drop_dates = [release["drop-date"] for release in releases["releases"]]
+    name_width = max(len("Package"), max(len(name) for name in release_names))
+    date_format = "%Y-%m-%d"
+    if release_date:
+        release_date_width = len("Release Date")
+    else:
+        release_date_width = 0
+
+    if drop_date:
+        drop_date_width = 10  # YYYY-MM-DD ; longer than "Drop Date"
+    else:
+        drop_date_width = 0
+
+    # print header
+    line = f"{'Package':<{name_width}}"
+    if release_date:
+        line += f" | {'Release Date':<{release_date_width}}"
+    if drop_date:
+        line += f" | {'Drop Date':<{drop_date_width}}"
+
+    print(line)
+    print("-" * len(line))
+    for name, date_release, date_drop in zip(release_names, release_dates, drop_dates):
+        line = f"{name:<{name_width}}"
+        if release_date:
+            line += f" | {date_release.strftime(date_format):<{release_date_width}}"
+        if drop_date:
+            line += f" | {date_drop.strftime(date_format):<{drop_date_width}}"
+
+        print(line)

--- a/src/spec0/main.py
+++ b/src/spec0/main.py
@@ -1,6 +1,10 @@
 from spec0.releasesource import PyPIReleaseSource, CondaReleaseSource
 from spec0.releasefilters import SPEC0StrictDate
 
+import logging
+
+_logger = logging.getLogger(__name__)
+
 
 def default_sources():
     return [
@@ -26,7 +30,7 @@ def main(package, sources=None, filter_=None):
             break
 
     filtered = filter_.filter(package, releases)
-    return {
+    result = {
         "package": package,
         "releases": [
             {
@@ -37,50 +41,5 @@ def main(package, sources=None, filter_=None):
             for release in filtered.values()
         ],
     }
-
-
-def _major_minor_str(version):
-    major_minor_str = f"{version.major}.{version.minor}"
-    if version.epoch != 0:
-        major_minor_str = f"{version.epoch}!{major_minor_str}"
-
-    return major_minor_str
-
-
-def terminal_output(pkg_info, release_date=True, drop_date=True):
-    package = pkg_info["package"]
-    release_names = [
-        f"{package} {_major_minor_str(release['version'])}"
-        for release in pkg_info["releases"]
-    ]
-    release_dates = [release["release-date"] for release in pkg_info["releases"]]
-    drop_dates = [release["drop-date"] for release in pkg_info["releases"]]
-    name_width = max(len("Package"), max(len(name) for name in release_names))
-    date_format = "%Y-%m-%d"
-    if release_date:
-        release_date_width = len("Release Date")
-    else:
-        release_date_width = 0
-
-    if drop_date:
-        drop_date_width = 10  # YYYY-MM-DD ; longer than "Drop Date"
-    else:
-        drop_date_width = 0
-
-    # print header
-    line = f"{'Package':<{name_width}}"
-    if release_date:
-        line += f" | {'Release Date':<{release_date_width}}"
-    if drop_date:
-        line += f" | {'Drop Date':<{drop_date_width}}"
-
-    print(line)
-    print("-" * len(line))
-    for name, date_release, date_drop in zip(release_names, release_dates, drop_dates):
-        line = f"{name:<{name_width}}"
-        if release_date:
-            line += f" | {date_release.strftime(date_format):<{release_date_width}}"
-        if drop_date:
-            line += f" | {date_drop.strftime(date_format):<{drop_date_width}}"
-
-        print(line)
+    _logger.info(result)
+    return result

--- a/src/spec0/output.py
+++ b/src/spec0/output.py
@@ -1,0 +1,79 @@
+import json
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+from datetime import datetime
+
+
+# TODO: move this to utils
+def make_specifier(pkg_info, include_upper_bound=True):
+    versions = [release["version"] for release in pkg_info["releases"]]
+    min_version = min(versions)
+    spec = SpecifierSet(f">={min_version}")
+    if include_upper_bound:
+        max_version = max(versions)
+        upper = Version(f"{max_version.major + 1}.0")
+        spec = spec & SpecifierSet(f"<{upper}")
+    return spec
+
+
+def _major_minor_str(version):
+    major_minor_str = f"{version.major}.{version.minor}"
+    if version.epoch != 0:
+        major_minor_str = f"{version.epoch}!{major_minor_str}"
+
+    return major_minor_str
+
+
+def json_output(pkg_info):
+    def default(obj):
+        if isinstance(obj, Version):
+            return str(obj)
+        elif isinstance(obj, datetime):
+            return obj.isoformat()
+        raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
+
+    print(json.dumps(pkg_info, indent=4, default=default))
+
+
+def specifier_output(pkg_info, include_upper_bound=True):
+    spec = make_specifier(pkg_info, include_upper_bound)
+    print(f"{pkg_info['package']} {spec}")
+
+
+def terminal_output(pkg_info, release_date=True, drop_date=True):
+    package = pkg_info["package"]
+    release_names = [
+        f"{package} {_major_minor_str(release['version'])}"
+        for release in pkg_info["releases"]
+    ]
+    release_dates = [release["release-date"] for release in pkg_info["releases"]]
+    drop_dates = [release["drop-date"] for release in pkg_info["releases"]]
+    name_width = max(len("Package"), max(len(name) for name in release_names))
+    date_format = "%Y-%m-%d"
+    if release_date:
+        release_date_width = len("Release Date")
+    else:
+        release_date_width = 0
+
+    if drop_date:
+        drop_date_width = 10  # YYYY-MM-DD ; longer than "Drop Date"
+    else:
+        drop_date_width = 0
+
+    # print header
+    line = f"{'Package':<{name_width}}"
+    if release_date:
+        line += f" | {'Release Date':<{release_date_width}}"
+    if drop_date:
+        line += f" | {'Drop Date':<{drop_date_width}}"
+
+    print(line)
+    print("-" * len(line))
+    for name, date_release, date_drop in zip(release_names, release_dates, drop_dates):
+        line = f"{name:<{name_width}}"
+        if release_date:
+            line += f" | {date_release.strftime(date_format):<{release_date_width}}"
+        if drop_date:
+            line += f" | {date_drop.strftime(date_format):<{drop_date_width}}"
+
+        print(line)

--- a/src/spec0/output.py
+++ b/src/spec0/output.py
@@ -1,27 +1,7 @@
 import json
-from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 from datetime import datetime
-
-
-# TODO: move this to utils
-def make_specifier(pkg_info, include_upper_bound=True):
-    versions = [release["version"] for release in pkg_info["releases"]]
-    min_version = min(versions)
-    spec = SpecifierSet(f">={min_version}")
-    if include_upper_bound:
-        max_version = max(versions)
-        upper = Version(f"{max_version.major + 1}.0")
-        spec = spec & SpecifierSet(f"<{upper}")
-    return spec
-
-
-def _major_minor_str(version):
-    major_minor_str = f"{version.major}.{version.minor}"
-    if version.epoch != 0:
-        major_minor_str = f"{version.epoch}!{major_minor_str}"
-
-    return major_minor_str
+from .utils.packaging import make_specifier, major_minor_str
 
 
 def json_output(pkg_info):
@@ -43,7 +23,7 @@ def specifier_output(pkg_info, include_upper_bound=True):
 def terminal_output(pkg_info, release_date=True, drop_date=True):
     package = pkg_info["package"]
     release_names = [
-        f"{package} {_major_minor_str(release['version'])}"
+        f"{package} {major_minor_str(release['version'])}"
         for release in pkg_info["releases"]
     ]
     release_dates = [release["release-date"] for release in pkg_info["releases"]]

--- a/src/spec0/releasefilters.py
+++ b/src/spec0/releasefilters.py
@@ -7,6 +7,10 @@ from packaging.version import Version
 
 from .releasesource import Release
 
+import logging
+
+_logger = logging.getLogger(__name__)
+
 
 class ReleaseFilter:
     def filter(self, package, releases): ...
@@ -108,6 +112,10 @@ class SPEC0(ReleaseFilter):
         for key, release in oldest_minor_release.items():
             drop_date = self.drop_date(package, release)
             if now < drop_date:
+                _logger.debug(
+                    f"Supporting {key} until {drop_date}, release date: "
+                    f"{release.release_date}"
+                )
                 supported[key] = release
 
         return supported

--- a/src/spec0/releasefilters.py
+++ b/src/spec0/releasefilters.py
@@ -6,6 +6,7 @@ from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
 from .releasesource import Release
+from .utils.dates import next_quarter, quarter_to_date, shift_date_by_months
 
 import logging
 
@@ -14,44 +15,6 @@ _logger = logging.getLogger(__name__)
 
 class ReleaseFilter:
     def filter(self, package, releases): ...
-
-
-# utils/dates
-def get_quarter(date):
-    """Convert a date to a quarter as tuple (year, quarter).
-
-    Quarters are 1-indexed.
-    """
-    return (date.year, ((date.month - 1) // 3) + 1)
-
-
-def next_quarter(date):
-    """Get the next quarter after the given date."""
-    year, quarter = get_quarter(date)
-    quarter += 1
-    if quarter > 4:
-        quarter = 1
-        year += 1
-    return (year, quarter)
-
-
-def quarter_to_date(quarter):
-    """
-    Convert a quarter to the date associated with the start of that quarter.
-    """
-    year, quarter = quarter
-    return datetime.datetime(
-        year, (quarter - 1) * 3 + 1, 1, tzinfo=datetime.timezone.utc
-    )
-
-
-def shift_date_by_months(date, n_months):
-    """Shift a date by a number of months."""
-    # used to set the cutoff; if there's a better way to do this, go for it.
-    # Months are weird because they aren't all the same length.
-    dyears = n_months // 12
-    dmonths = n_months % 12
-    return date.replace(year=date.year + dyears, month=date.month + dmonths)
 
 
 def get_oldest_minor_release(releases: Iterable[Release]):

--- a/src/spec0/releasesource.py
+++ b/src/spec0/releasesource.py
@@ -9,6 +9,10 @@ from typing import Generator
 
 from spec0.cacheddownload import get_file, CACHE_DIR
 
+import logging
+
+_logger = logging.getLogger(__name__)
+
 
 @dataclasses.dataclass
 class Release:
@@ -36,6 +40,7 @@ class PyPIReleaseSource(ReleaseSource):
 
     def _get_releases(self, package: str) -> Generator[Release, None, None]:
         url = f"https://pypi.org/pypi/{package}/json"
+        _logger.debug(f"Fetching {url}")
         response = requests.get(url)
         response.raise_for_status()
         data = response.json()
@@ -64,9 +69,9 @@ class PyPIReleaseSource(ReleaseSource):
 
             # Only add to list if we successfully found an upload date
             if earliest_date is not None:
-                release_list.append(
-                    Release(version=parsed_version, release_date=earliest_date)
-                )
+                release = Release(version=parsed_version, release_date=earliest_date)
+                _logger.debug(f"Found release: {release}")
+                release_list.append(release)
 
         release_list.sort(key=lambda r: r.release_date, reverse=True)
         for release in release_list:

--- a/src/spec0/utils/dates.py
+++ b/src/spec0/utils/dates.py
@@ -1,0 +1,39 @@
+import datetime
+
+
+# utils/dates
+def get_quarter(date):
+    """Convert a date to a quarter as tuple (year, quarter).
+
+    Quarters are 1-indexed.
+    """
+    return (date.year, ((date.month - 1) // 3) + 1)
+
+
+def next_quarter(date):
+    """Get the next quarter after the given date."""
+    year, quarter = get_quarter(date)
+    quarter += 1
+    if quarter > 4:
+        quarter = 1
+        year += 1
+    return (year, quarter)
+
+
+def quarter_to_date(quarter):
+    """
+    Convert a quarter to the date associated with the start of that quarter.
+    """
+    year, quarter = quarter
+    return datetime.datetime(
+        year, (quarter - 1) * 3 + 1, 1, tzinfo=datetime.timezone.utc
+    )
+
+
+def shift_date_by_months(date, n_months):
+    """Shift a date by a number of months."""
+    # used to set the cutoff; if there's a better way to do this, go for it.
+    # Months are weird because they aren't all the same length.
+    dyears = n_months // 12
+    dmonths = n_months % 12
+    return date.replace(year=date.year + dyears, month=date.month + dmonths)

--- a/src/spec0/utils/packaging.py
+++ b/src/spec0/utils/packaging.py
@@ -8,7 +8,7 @@ def make_specifier(pkg_info, include_upper_bound=True):
     spec = SpecifierSet(f">={min_version}")
     if include_upper_bound:
         max_version = max(versions)
-        upper = Version(f"{max_version.major + 1}.0")
+        upper = Version(f"{max_version.epoch}!{max_version.major + 1}.0")
         spec = spec & SpecifierSet(f"<{upper}")
     return spec
 

--- a/src/spec0/utils/packaging.py
+++ b/src/spec0/utils/packaging.py
@@ -1,0 +1,21 @@
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+
+def make_specifier(pkg_info, include_upper_bound=True):
+    versions = [release["version"] for release in pkg_info["releases"]]
+    min_version = min(versions)
+    spec = SpecifierSet(f">={min_version}")
+    if include_upper_bound:
+        max_version = max(versions)
+        upper = Version(f"{max_version.major + 1}.0")
+        spec = spec & SpecifierSet(f"<{upper}")
+    return spec
+
+
+def major_minor_str(version):
+    major_minor_str = f"{version.major}.{version.minor}"
+    if version.epoch != 0:
+        major_minor_str = f"{version.epoch}!{major_minor_str}"
+
+    return major_minor_str

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,153 @@
+import datetime
+import pytest
+from packaging.version import Version
+
+from spec0.releasesource import PyPIReleaseSource, CondaReleaseSource, Release
+from spec0.releasefilters import SPEC0StrictDate
+
+from spec0.main import *
+from spec0.main import _major_minor_str
+
+
+class DummySource:
+    """
+    A dummy source that implements get_releases.
+    It returns a dictionary of releases if provided,
+    otherwise returns None.
+    """
+
+    def __init__(self, releases):
+        self._releases = releases
+
+    def get_releases(self, package):
+        return self._releases
+
+
+class DummyFilter:
+    """
+    A dummy filter that simply passes through releases.
+    Its drop_date method returns a fixed date.
+    """
+
+    def filter(self, package, releases):
+        return releases
+
+    def drop_date(self, package, release):
+        return datetime.datetime(2021, 1, 1)
+
+
+def test_default_sources():
+    sources = default_sources()
+    assert isinstance(sources, list)
+    assert len(sources) == 2
+
+    assert isinstance(sources[0], PyPIReleaseSource)
+    assert isinstance(sources[1], CondaReleaseSource)
+
+
+def test_default_filter():
+    filter_obj = default_filter()
+    assert isinstance(filter_obj, SPEC0StrictDate)
+    assert filter_obj.n_months == 24
+    assert filter_obj.python_override is True
+
+
+@pytest.mark.parametrize(
+    "version_str,expected",
+    [
+        ("1.2", "1.2"),  # For "1.2", epoch is 0, so just "major.minor"
+        ("1!1.2", "1!1.2"),  # For "1!1.2", non-zero epoch is included
+        ("0.3.4", "0.3"),  # For "0.3.4", only major and minor are used
+    ],
+)
+def test_major_minor_str(version_str, expected):
+    v = Version(version_str)
+    result = _major_minor_str(v)
+    assert result == expected
+
+
+def test_main_uses_first_source_with_releases():
+    v = Version("1.0")
+    release_date = datetime.datetime(2020, 1, 1)
+    dummy_release = Release(v, release_date)
+
+    # The first source returns a valid releases dict.
+    # The second source should not be used.
+    source1 = DummySource({"r1": dummy_release})
+    v2 = Version("2.0")
+    source2 = DummySource({"r2": Release(v2, datetime.datetime(2020, 2, 2))})
+
+    filter_obj = DummyFilter()
+    result = main("testpkg", sources=[source1, source2], filter_=filter_obj)
+
+    assert result["package"] == "testpkg"
+    assert isinstance(result["releases"], list)
+    assert len(result["releases"]) == 1
+    release_info = result["releases"][0]
+    assert release_info["version"] == v
+    assert release_info["release-date"] == release_date
+    assert release_info["drop-date"] == datetime.datetime(2021, 1, 1)
+
+
+def test_main_uses_second_source_when_first_returns_none():
+    v = Version("1.0")
+    release_date = datetime.datetime(2020, 1, 1)
+    dummy_release = Release(v, release_date)
+
+    source1 = DummySource(None)
+    source2 = DummySource({"r1": dummy_release})
+
+    filter_obj = DummyFilter()
+    result = main("testpkg", sources=[source1, source2], filter_=filter_obj)
+
+    assert result["package"] == "testpkg"
+    assert isinstance(result["releases"], list)
+    assert len(result["releases"]) == 1
+
+
+@pytest.mark.parametrize("release_date", [True, False])
+@pytest.mark.parametrize("drop_date", [True, False])
+def test_terminal_output_combined(capsys, release_date, drop_date):
+    pkg_info = {
+        "package": "mypackage",
+        "releases": [
+            {
+                "version": Version("1.0"),
+                "release-date": datetime.datetime(2020, 1, 1),
+                "drop-date": datetime.datetime(2021, 1, 1),
+            },
+            {
+                "version": Version("1!2.3"),
+                "release-date": datetime.datetime(2020, 2, 2),
+                "drop-date": datetime.datetime(2021, 2, 2),
+            },
+        ],
+    }
+
+    terminal_output(pkg_info, release_date=release_date, drop_date=drop_date)
+    captured = capsys.readouterr().out
+    header_line, _, first_row, second_row = captured.splitlines()
+
+    # Fixed assertions that are always expected.
+    assert "Package" in header_line
+    assert "mypackage 1.0" in first_row
+    assert "mypackage 1!2.3" in second_row
+
+    # Check header for release date and drop date based on flags.
+    if release_date:
+        assert "Release Date" in header_line
+        assert "2020-01-01" in first_row
+        assert "2020-02-02" in second_row
+    else:
+        assert "Release Date" not in header_line
+        assert "2020-01-01" not in first_row
+        assert "2020-02-02" not in second_row
+
+    if drop_date:
+        assert "Drop Date" in header_line
+        assert "2021-01-01" in first_row
+        assert "2021-02-02" in second_row
+    else:
+        assert "Drop Date" not in header_line
+        assert "2021-01-01" not in first_row
+        assert "2021-02-02" not in second_row

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,53 @@
+import pytest
+
+from spec0.output import *
+from packaging.version import Version
+import datetime
+
+
+@pytest.mark.parametrize("release_date", [True, False])
+@pytest.mark.parametrize("drop_date", [True, False])
+def test_terminal_output_combined(capsys, release_date, drop_date):
+    pkg_info = {
+        "package": "mypackage",
+        "releases": [
+            {
+                "version": Version("1.0"),
+                "release-date": datetime.datetime(2020, 1, 1),
+                "drop-date": datetime.datetime(2021, 1, 1),
+            },
+            {
+                "version": Version("1!2.3"),
+                "release-date": datetime.datetime(2020, 2, 2),
+                "drop-date": datetime.datetime(2021, 2, 2),
+            },
+        ],
+    }
+
+    terminal_output(pkg_info, release_date=release_date, drop_date=drop_date)
+    captured = capsys.readouterr().out
+    header_line, _, first_row, second_row = captured.splitlines()
+
+    # Fixed assertions that are always expected.
+    assert "Package" in header_line
+    assert "mypackage 1.0" in first_row
+    assert "mypackage 1!2.3" in second_row
+
+    # Check header for release date and drop date based on flags.
+    if release_date:
+        assert "Release Date" in header_line
+        assert "2020-01-01" in first_row
+        assert "2020-02-02" in second_row
+    else:
+        assert "Release Date" not in header_line
+        assert "2020-01-01" not in first_row
+        assert "2020-02-02" not in second_row
+
+    if drop_date:
+        assert "Drop Date" in header_line
+        assert "2021-01-01" in first_row
+        assert "2021-02-02" in second_row
+    else:
+        assert "Drop Date" not in header_line
+        assert "2021-01-01" not in first_row
+        assert "2021-02-02" not in second_row

--- a/tests/test_releasefilters.py
+++ b/tests/test_releasefilters.py
@@ -32,45 +32,6 @@ def releases():
     return releases
 
 
-@pytest.mark.parametrize(
-    "datetime, expected",
-    [
-        (datetime.datetime(2023, 5, 15), (2023, 2)),
-        (datetime.datetime(2023, 1, 1), (2023, 1)),
-        (datetime.datetime(2023, 12, 31), (2023, 4)),
-    ],
-)
-def test_get_quarter(datetime, expected):
-    assert get_quarter(datetime) == expected
-
-
-@pytest.mark.parametrize(
-    "datetime, expected",
-    [
-        (datetime.datetime(2023, 5, 15), (2023, 3)),
-        (datetime.datetime(2023, 11, 1), (2024, 1)),  # bump the year
-    ],
-)
-def test_next_quarter(datetime, expected):
-    assert next_quarter(datetime) == expected
-
-
-def test_quarter_to_date():
-    expected = datetime.datetime(2023, 4, 1, tzinfo=datetime.timezone.utc)
-    assert quarter_to_date((2023, 2)) == expected
-
-
-@pytest.mark.parametrize(
-    "datetime, n_months, expected",
-    [
-        (datetime.datetime(2023, 1, 15), 3, datetime.datetime(2023, 4, 15)),
-        (datetime.datetime(2023, 7, 15), 4, datetime.datetime(2023, 11, 15)),
-    ],
-)
-def test_shift_date_by_months(datetime, n_months, expected):
-    assert shift_date_by_months(datetime, n_months) == expected
-
-
 def test_get_oldest_minor_release():
     r1 = Release(
         version=Version("1.0.0"),

--- a/tests/utils/test_dates.py
+++ b/tests/utils/test_dates.py
@@ -1,0 +1,43 @@
+import datetime
+import pytest
+
+from spec0.utils.dates import *
+
+
+@pytest.mark.parametrize(
+    "datetime, expected",
+    [
+        (datetime.datetime(2023, 5, 15), (2023, 2)),
+        (datetime.datetime(2023, 1, 1), (2023, 1)),
+        (datetime.datetime(2023, 12, 31), (2023, 4)),
+    ],
+)
+def test_get_quarter(datetime, expected):
+    assert get_quarter(datetime) == expected
+
+
+@pytest.mark.parametrize(
+    "datetime, expected",
+    [
+        (datetime.datetime(2023, 5, 15), (2023, 3)),
+        (datetime.datetime(2023, 11, 1), (2024, 1)),  # bump the year
+    ],
+)
+def test_next_quarter(datetime, expected):
+    assert next_quarter(datetime) == expected
+
+
+def test_quarter_to_date():
+    expected = datetime.datetime(2023, 4, 1, tzinfo=datetime.timezone.utc)
+    assert quarter_to_date((2023, 2)) == expected
+
+
+@pytest.mark.parametrize(
+    "datetime, n_months, expected",
+    [
+        (datetime.datetime(2023, 1, 15), 3, datetime.datetime(2023, 4, 15)),
+        (datetime.datetime(2023, 7, 15), 4, datetime.datetime(2023, 11, 15)),
+    ],
+)
+def test_shift_date_by_months(datetime, n_months, expected):
+    assert shift_date_by_months(datetime, n_months) == expected

--- a/tests/utils/test_packaging.py
+++ b/tests/utils/test_packaging.py
@@ -1,8 +1,93 @@
 from packaging.version import Version
+from packaging.specifiers import SpecifierSet
 
 import pytest
 
 from spec0.utils.packaging import *
+
+
+@pytest.mark.parametrize(
+    "pkg_info, include_upper_bound, expected",
+    [
+        # Single release: only one version provided.
+        (
+            {"releases": [{"version": Version("1.2.3")}]},
+            True,
+            ">=1.2.3,<2.0",
+        ),
+        (
+            {"releases": [{"version": Version("1.2.3")}]},
+            False,
+            ">=1.2.3",
+        ),
+        # Multiple releases with the same major version.
+        (
+            {
+                "releases": [
+                    {"version": Version("1.2.3")},
+                    {"version": Version("1.3.0")},
+                ]
+            },
+            True,
+            ">=1.2.3,<2.0",
+        ),
+        (
+            {
+                "releases": [
+                    {"version": Version("1.2.3")},
+                    {"version": Version("1.3.0")},
+                ]
+            },
+            False,
+            ">=1.2.3",
+        ),
+        # Multiple releases with different major versions.
+        (
+            {
+                "releases": [
+                    {"version": Version("1.2.3")},
+                    {"version": Version("2.0.0")},
+                ]
+            },
+            True,
+            ">=1.2.3,<3.0",
+        ),
+        (
+            {
+                "releases": [
+                    {"version": Version("1.2.3")},
+                    {"version": Version("2.0.0")},
+                ]
+            },
+            False,
+            ">=1.2.3",
+        ),
+        # Releases with a nonzero epoch.
+        (
+            {
+                "releases": [
+                    {"version": Version("2!1.0")},
+                    {"version": Version("2!3.0")},
+                ]
+            },
+            True,
+            ">=2!1.0,<2!4.0",
+        ),
+        (
+            {
+                "releases": [
+                    {"version": Version("2!1.0")},
+                    {"version": Version("2!3.0")},
+                ]
+            },
+            False,
+            ">=2!1.0",
+        ),
+    ],
+)
+def test_make_specifier(pkg_info, include_upper_bound, expected):
+    spec = make_specifier(pkg_info, include_upper_bound)
+    assert spec == SpecifierSet(expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_packaging.py
+++ b/tests/utils/test_packaging.py
@@ -1,0 +1,19 @@
+from packaging.version import Version
+
+import pytest
+
+from spec0.utils.packaging import *
+
+
+@pytest.mark.parametrize(
+    "version_str,expected",
+    [
+        ("1.2", "1.2"),  # For "1.2", epoch is 0, so just "major.minor"
+        ("1!1.2", "1!1.2"),  # For "1!1.2", non-zero epoch is included
+        ("0.3.4", "0.3"),  # For "0.3.4", only major and minor are used
+    ],
+)
+def test_major_minor_str(version_str, expected):
+    v = Version(version_str)
+    result = major_minor_str(v)
+    assert result == expected


### PR DESCRIPTION
Mostly this is the CLI. Aspects of the CLI are split into a few files:

* `cli.py`: parses CLI input
* `main.py`: runs the main function: gets a set of releases and filters them, providing the `pkg_info` dict.
* `output.py`: various ways of converting the `pkg_info` dict to on-screen output.

This also involved moving some utilities under `utils/dates.py` and `utils/packaging.py`.