### PR TITLE
Release Source: GitHub Tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Run tests
         run: python -m pytest --cov -v
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # needed for some tests
 
       - name: Upload coverage
         uses: codecov/codecov-action@v5

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include src/spec0/data/*.json

--- a/src/spec0/cli.py
+++ b/src/spec0/cli.py
@@ -8,6 +8,7 @@ from spec0.releasesource import (
     PyPIReleaseSource,
     CondaReleaseSource,
     GitHubReleaseSource,
+    DefaultReleaseSource,
 )
 from spec0.releasefilters import SPEC0StrictDate, SPEC0Quarter
 from spec0.output import terminal_output, json_output, specifier_output
@@ -123,24 +124,19 @@ def select_source(opts):
     selected_conda = opts.conda_channel is not None
     selected_github = opts.github
     n_selected = sum([selected_pypi, selected_conda, selected_github])
+    token = os.getenv("GITHUB_TOKEN")
     if n_selected == 0:
-        source = None
+        source = DefaultReleaseSource(token)
     elif n_selected > 1:
         raise ValueError("Only one source can be selected")
     else:
         if selected_pypi:
-            source = [PyPIReleaseSource()]
+            source = PyPIReleaseSource()
         elif selected_conda:
             platforms = [f"{opts.conda_channel}/{arch}" for arch in opts.conda_arch]
-            source = [CondaReleaseSource(platforms)]
+            source = CondaReleaseSource(platforms)
         elif selected_github:
-            if (token := os.getenv("GITHUB_TOKEN")) is None:
-                raise ValueError(
-                    "GITHUB_TOKEN environment variable must be set to use GitHub "
-                    "releases"
-                )
-
-            source = [GitHubReleaseSource(token)]
+            source = GitHubReleaseSource(token)
 
     return source
 

--- a/src/spec0/data/github-releases.json
+++ b/src/spec0/data/github-releases.json
@@ -1,0 +1,3 @@
+{
+    "rust":  "rust-lang/rust"
+}

--- a/src/spec0/data/github-releases.json
+++ b/src/spec0/data/github-releases.json
@@ -1,3 +1,4 @@
 {
-    "rust":  "rust-lang/rust"
+    "rust":  "rust-lang/rust",
+    "python": "python/cpython"
 }

--- a/src/spec0/main.py
+++ b/src/spec0/main.py
@@ -1,4 +1,3 @@
-from spec0.releasesource import PyPIReleaseSource, CondaReleaseSource
 from spec0.releasefilters import SPEC0StrictDate
 
 import logging
@@ -6,28 +5,20 @@ import logging
 _logger = logging.getLogger(__name__)
 
 
-def default_sources():
-    """Default release sources if none are provided."""
-    return [
-        PyPIReleaseSource(),
-        CondaReleaseSource(["conda-forge/noarch", "conda-forge/linux-64"]),
-    ]
-
-
 def default_filter():
     """Default support filter if none is provided."""
     return SPEC0StrictDate()
 
 
-def main(package, sources=None, filter_=None):
+def main(package, source, filter_=None):
     """Main function to get release info for a package.
 
     Parameters
     ----------
     package : str
         The name of the package to get release info for.
-    sources : list, optional
-        A list of release sources to use. If None, default sources are used.
+    source : ReleaseSource
+        The source to use for getting release info.
     filter_ : ReleaseFilter, optional
         A release filter to use. If None, default filter is used.
 
@@ -42,17 +33,10 @@ def main(package, sources=None, filter_=None):
         (datetime) release date of the release, and "drop-date" is the
         (datetime) drop date of the release, according to the input filter.
     """
-    if sources is None:
-        sources = default_sources()
-
     if filter_ is None:
         filter_ = default_filter()
 
-    # we take the releases from the first source that has them
-    for source in sources:
-        if releases := source.get_releases(package):
-            break
-
+    releases = source.get_releases(package)
     filtered = filter_.filter(package, releases)
     result = {
         "package": package,

--- a/src/spec0/releasefilters.py
+++ b/src/spec0/releasefilters.py
@@ -5,7 +5,7 @@ from typing import Iterable
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
-from .releasesource import Release
+from .releasesource import Release, NoReleaseFound
 from .utils.dates import next_quarter, quarter_to_date, shift_date_by_months
 
 import logging
@@ -68,8 +68,8 @@ class SPEC0(ReleaseFilter):
 
         try:
             max_minor_release = max(oldest_minor_release)
-        except ValueError:  # no releases found
-            raise RuntimeError(f"No releases found for package '{package}'")
+        except ValueError:  # no releases found; should be caught by source
+            raise NoReleaseFound(f"No releases found for package '{package}'")
         # always support at least the most recent minor release
         supported = {max_minor_release: oldest_minor_release[max_minor_release]}
 

--- a/src/spec0/releasefilters.py
+++ b/src/spec0/releasefilters.py
@@ -66,7 +66,10 @@ class SPEC0(ReleaseFilter):
     def _get_minimum_supported(self, package: str, releases: Iterable[Release]):
         oldest_minor_release = get_oldest_minor_release(releases)
 
-        max_minor_release = max(oldest_minor_release)
+        try:
+            max_minor_release = max(oldest_minor_release)
+        except ValueError:  # no releases found
+            raise RuntimeError(f"No releases found for package '{package}'")
         # always support at least the most recent minor release
         supported = {max_minor_release: oldest_minor_release[max_minor_release]}
 

--- a/src/spec0/releasesource.py
+++ b/src/spec0/releasesource.py
@@ -74,17 +74,16 @@ class PyPIReleaseSource(ReleaseSource):
 
 
 class GitHubReleaseSource(ReleaseSource):
-    """Class to fetch all GitHub releases for a given repository using the GitHub GraphQL API."""
+    """
+    Class to fetch all GitHub releases for a given repository using the GitHub GraphQL API.
+
+    Parameters
+    ----------
+    github_token : str
+        Personal access token (PAT) with permissions to query the desired repository.
+    """
 
     def __init__(self, github_token: str):
-        """
-        Initialize the release source with a GitHub token.
-
-        Parameters
-        ----------
-        github_token : str
-            Personal access token (PAT) with permissions to query the desired repository.
-        """
         self.github_token = github_token
 
     def _get_releases(self, owner_repo: str):

--- a/src/spec0/releasesource.py
+++ b/src/spec0/releasesource.py
@@ -195,7 +195,7 @@ class GitHubReleaseSource(ReleaseSource):
 
         url = "https://api.github.com/graphql"
         headers = {
-            "Authorization": f"Bearer {self.github_token}",
+            "Authorization": f"Bearer {token}",
             "Accept": "application/vnd.github.v3+json",
         }
 

--- a/src/spec0/releasesource.py
+++ b/src/spec0/releasesource.py
@@ -203,6 +203,8 @@ class GitHubReleaseSource(ReleaseSource):
         has_next_page = True
         after_cursor = None
 
+        found_package = False
+
         while has_next_page:
             variables = {
                 "owner": owner,
@@ -234,9 +236,15 @@ class GitHubReleaseSource(ReleaseSource):
                     datestr.replace("Z", "+00:00")
                 )
                 yield Release(version, release_date)
+                found_package = True
 
             has_next_page = releases_data["pageInfo"]["hasNextPage"]
             after_cursor = releases_data["pageInfo"]["endCursor"]
+
+        if not found_package:
+            raise NoReleaseFound(
+                f"No releases found for GitHub repository '{owner_repo}'"
+            )
 
 
 class CondaReleaseSource(ReleaseSource):

--- a/src/spec0/releasesource.py
+++ b/src/spec0/releasesource.py
@@ -89,7 +89,8 @@ class GitHubReleaseSource(ReleaseSource):
 
     def _get_releases(self, owner_repo: str):
         """
-        Generate all releases for a repository in descending order of creation date (most recent first).
+        Generate all releases for a repository in descending order of
+        creation date (most recent first).
 
         Parameters
         ----------
@@ -158,7 +159,7 @@ class GitHubReleaseSource(ReleaseSource):
                     warnings.warn(f"Skipping invalid version: {tag_name}", UserWarning)
                     continue  # Skip this release
 
-                release_date = datetime.fromisoformat(
+                release_date = datetime.datetime.fromisoformat(
                     node["createdAt"].replace("Z", "+00:00")
                 )
                 yield Release(version, release_date)

--- a/src/spec0/releasesource.py
+++ b/src/spec0/releasesource.py
@@ -6,7 +6,6 @@ import requests
 import warnings
 from packaging.version import Version, InvalidVersion
 import importlib.resources
-import collections
 
 from typing import Generator
 
@@ -112,7 +111,7 @@ class GitHubReleaseSource(ReleaseSource):
 
     def is_github_package(self, package: str) -> bool:
         """Check if the package is a GitHub package."""
-        if collections.Counter(package).get("/") == 1:
+        if package.count("/") == 1:
             return True
         elif package in self.canonical_sources:
             return True
@@ -120,7 +119,7 @@ class GitHubReleaseSource(ReleaseSource):
             return False
 
     def _get_releases(self, package: str):
-        if collections.Counter(package).get("/") == 1:
+        if package.count("/") == 1:
             owner_repo = package
         elif package in self.canonical_sources:
             owner_repo = self.canonical_sources[package]

--- a/tests/test_releasefilters.py
+++ b/tests/test_releasefilters.py
@@ -4,6 +4,7 @@ from packaging.version import Version
 from unittest.mock import patch
 
 from spec0.releasefilters import *
+from spec0.releasesource import NoReleaseFound
 
 read_datetime = datetime.datetime
 
@@ -104,6 +105,15 @@ class TestSPEC0StrictDate:
                 )
                 assert key in supported
 
+    def test_filter_empty_releases(self):
+        package_name = "nonexistent-package"
+        spec_strict = SPEC0StrictDate()
+
+        with pytest.raises(
+            NoReleaseFound, match=f"No releases found for package '{package_name}'"
+        ):
+            spec_strict.filter(package_name, [])
+
     @pytest.mark.parametrize("python_override", [True, False])
     @pytest.mark.parametrize("package", ["foo", "python"])
     def test_drop_date(self, python_override, package):
@@ -140,6 +150,15 @@ class TestSPEC0Quarter:
                     release.version.minor,
                 )
                 assert key in supported
+
+    def test_filter_empty_releases(self):
+        package_name = "nonexistent-package"
+        spec_quarter = SPEC0Quarter()
+
+        with pytest.raises(
+            NoReleaseFound, match=f"No releases found for package '{package_name}'"
+        ):
+            spec_quarter.filter(package_name, [])
 
     @pytest.mark.parametrize("python_override", [True, False])
     @pytest.mark.parametrize("package", ["foo", "python"])

--- a/tests/test_releasesource.py
+++ b/tests/test_releasesource.py
@@ -188,12 +188,21 @@ class TestCondaReleaseSource:
 MOCK_GH_RESPONSE_VALID_ONLY = {
     "data": {
         "repository": {
-            "releases": {
+            "refs": {
                 "pageInfo": {"endCursor": None, "hasNextPage": False},
                 "nodes": [
-                    {"tagName": "2.2.0", "createdAt": "2023-03-03T12:00:00Z"},
-                    {"tagName": "2.1.0", "createdAt": "2023-02-10T09:00:00Z"},
-                    {"tagName": "1.9.0", "createdAt": "2023-01-15T20:00:00Z"},
+                    {
+                        "name": "v2.2.0",
+                        "target": {"committedDate": "2023-03-03T12:00:00Z"},
+                    },
+                    {
+                        "name": "2.1.0",
+                        "target": {"tagger": {"date": "2023-02-10T09:00:00Z"}},
+                    },
+                    {
+                        "name": "1.9.0",
+                        "target": {"committedDate": "2023-01-15T20:00:00Z"},
+                    },
                 ],
             }
         }
@@ -203,15 +212,21 @@ MOCK_GH_RESPONSE_VALID_ONLY = {
 MOCK_GH_RESPONSE_MIXED = {
     "data": {
         "repository": {
-            "releases": {
+            "refs": {
                 "pageInfo": {"endCursor": None, "hasNextPage": False},
                 "nodes": [
-                    {"tagName": "10.0.0", "createdAt": "2024-01-01T12:00:00Z"},
                     {
-                        "tagName": "not-a-valid-version",
-                        "createdAt": "2024-01-02T12:00:00Z",
+                        "name": "10.0.0",
+                        "target": {"committedDate": "2024-01-01T12:00:00Z"},
                     },
-                    {"tagName": "9.9.9", "createdAt": "2023-12-15T12:00:00Z"},
+                    {
+                        "name": "not-a-valid-version",
+                        "target": {"committedDate": "2024-01-02T12:00:00Z"},
+                    },
+                    {
+                        "name": "9.9.9",
+                        "target": {"committedDate": "2023-12-15T12:00:00Z"},
+                    },
                 ],
             }
         }
@@ -221,11 +236,17 @@ MOCK_GH_RESPONSE_MIXED = {
 MOCK_GH_RESPONSE_PAGE1 = {
     "data": {
         "repository": {
-            "releases": {
+            "refs": {
                 "pageInfo": {"endCursor": "CURSOR1", "hasNextPage": True},
                 "nodes": [
-                    {"tagName": "3.0.0", "createdAt": "2024-01-05T12:00:00Z"},
-                    {"tagName": "2.5.0", "createdAt": "2023-12-20T12:00:00Z"},
+                    {
+                        "name": "3.0.0",
+                        "target": {"committedDate": "2024-01-05T12:00:00Z"},
+                    },
+                    {
+                        "name": "2.5.0",
+                        "target": {"committedDate": "2023-12-20T12:00:00Z"},
+                    },
                 ],
             }
         }
@@ -235,11 +256,17 @@ MOCK_GH_RESPONSE_PAGE1 = {
 MOCK_GH_RESPONSE_PAGE2 = {
     "data": {
         "repository": {
-            "releases": {
+            "refs": {
                 "pageInfo": {"endCursor": None, "hasNextPage": False},
                 "nodes": [
-                    {"tagName": "2.2.0", "createdAt": "2023-11-10T12:00:00Z"},
-                    {"tagName": "2.0.0", "createdAt": "2023-10-01T12:00:00Z"},
+                    {
+                        "name": "2.2.0",
+                        "target": {"committedDate": "2023-11-10T12:00:00Z"},
+                    },
+                    {
+                        "name": "2.0.0",
+                        "target": {"committedDate": "2023-10-01T12:00:00Z"},
+                    },
                 ],
             }
         }
@@ -355,7 +382,7 @@ class TestGitHubReleaseSource:
     @pytest.mark.skipif(
         not os.environ.get("GITHUB_TOKEN"), reason="GITHUB_TOKEN not set"
     )
-    def test_integration_openpathsampling(self):
+    def test_integration_python(self):
         """
         Integration test using the real GitHub API to fetch releases for the
         repository openpathsampling/openpathsampling. Checks that at least one
@@ -363,7 +390,5 @@ class TestGitHubReleaseSource:
         """
         token = os.environ["GITHUB_TOKEN"]
         source = GitHubReleaseSource(token)
-        releases = list(source.get_releases("openpathsampling/openpathsampling"))
+        releases = list(source.get_releases("python"))
         assert len(releases) > 0
-        release_dates = [r.release_date for r in releases]
-        assert_is_descending(release_dates)

--- a/tests/test_releasesource.py
+++ b/tests/test_releasesource.py
@@ -384,7 +384,7 @@ class TestGitHubReleaseSource:
     @pytest.mark.skipif(
         not os.environ.get("GITHUB_TOKEN"), reason="GITHUB_TOKEN not set"
     )
-    def test_integration_python(self):
+    def test_integration(self):
         """
         Integration test using the real GitHub API to fetch releases for the
         repository openpathsampling/openpathsampling. Checks that at least one
@@ -392,8 +392,9 @@ class TestGitHubReleaseSource:
         """
         token = os.environ["GITHUB_TOKEN"]
         source = GitHubReleaseSource(token)
-        releases = list(source.get_releases("python"))
-        assert len(releases) > 0
+        for package in source.canonical_sources:
+            releases = list(source.get_releases(package))
+            assert len(releases) > 0
 
 
 def make_release(version: str, date_str: str):

--- a/tests/test_releasesource.py
+++ b/tests/test_releasesource.py
@@ -396,6 +396,25 @@ class TestGitHubReleaseSource:
             releases = list(source.get_releases(package))
             assert len(releases) > 0
 
+    @pytest.mark.parametrize(
+        "package,expected",
+        [
+            ("owner/repo", True),
+            ("python", True),
+            ("package-without-slash", False),
+            ("too/many/slashes", False),
+            ("", False),
+        ],
+    )
+    def test_is_github_package(self, package, expected):
+        """Test the is_github_package method with various inputs."""
+        source = GitHubReleaseSource("FAKE_TOKEN")
+        # Ensure the canonical_sources has expected entries
+        source.canonical_sources = {"python": "python/cpython"}
+
+        result = source.is_github_package(package)
+        assert result == expected
+
 
 def make_release(version: str, date_str: str):
     dt = datetime.datetime.fromisoformat(date_str).replace(tzinfo=datetime.timezone.utc)


### PR DESCRIPTION
This also includes a translation that maps names of known packages to repos (e.g., "python" becomes "python/cpython").

TODO:
- [x] Add this into the main CLI; if the package looks like a repo name or is in the list of known repos, we default to using GitHub
- [x] Testing should probably include (optionally?) smoke tests on all known names