### PR TITLE
Fix docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,10 +5,8 @@
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
-import sys
-import os
 
-sys.path.insert(0, os.path.abspath("../src/spec0"))
+# sys.path.insert(0, os.path.abspath("../src/spec0"))
 
 project = "SPEC0"
 copyright = "2025, David W.H. Swenson"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,10 +49,6 @@ docs = [
 [project.scripts]
 spec0 = "spec0.cli:cli_main"
 
-[tool.setuptools]
-packages = ["spec0"]
-package-dir = { "" = "src" }
-
 [tool.pixi.project]
 channels = ["conda-forge"]
 platforms = ["osx-64"]


### PR DESCRIPTION
Build on RTD was missing information. This PR will fix it.

Looks like the problem was that we weren't trusting setuptools to find packages on its own.