### PR TITLE
Rename package/repo to spec0-tools

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy_pypi:
-    if: ${{ github.repository == 'omsf/spec0' }}
+    if: ${{ github.repository == 'omsf/spec0-tools' }}
     runs-on: ubuntu-latest
     name: "Publish on PyPI"
     permissions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "spec0"
-version = "0.0.1.dev0"
+name = "spec0-tools"
+version = "0.1.0"
 description = "A tool to check which versions of a package should be supported according to SPEC0."
 authors = [
   { name = "David W.H. Swenson", email = "dwhs@hyperblazer.net" }


### PR DESCRIPTION
This is to avoid potential issues with the name spec0 on PyPI. The PyPI name changes, but the CLI command and import name do not.

Also sets the version number as ready for release!